### PR TITLE
feat: Add module_size parameter into QRImage()

### DIFF
--- a/example.py
+++ b/example.py
@@ -22,7 +22,7 @@ def main():
     # print(qr)
 
     # Save as png
-    image = QRImage(qr)
+    image = QRImage(qr, module_size=8)
     image.show()
     image.save("my_qr.png")
 

--- a/src/rmqrcode/qr_image.py
+++ b/src/rmqrcode/qr_image.py
@@ -1,11 +1,17 @@
 from .enums.color import Color
 
 from PIL import Image
+from PIL import ImageDraw
 
 
 class QRImage:
-    def __init__(self, qr):
-        self._img = Image.new('RGB', (qr.width() + 4, qr.height() + 4), (255, 255, 255))
+    def __init__(self, qr, module_size=10):
+        self._module_size = module_size
+        self._img = Image.new(
+            'RGB',
+            ((qr.width() + 4) * module_size, (qr.height() + 4) * module_size),
+            (255, 255, 255)
+        )
         self._make_image(qr)
 
 
@@ -19,6 +25,7 @@ class QRImage:
 
 
     def _make_image(self, qr):
+        draw = ImageDraw.Draw(self._img)
         for y in range(qr.height()):
             for x in range(qr.width()):
                 r, g, b = 125, 125, 125
@@ -26,4 +33,7 @@ class QRImage:
                     r, g, b = 0, 0, 0
                 elif qr.value_at(x, y) == Color.WHITE:
                     r, g, b, = 255, 255, 255
-                self._img.putpixel((x+2, y+2), (r, g, b))
+                draw.rectangle(
+                    xy=((x + 2) * self._module_size, (y + 2) * self._module_size, (x + 1 + 2) * self._module_size, (y + 1 + 2) * self._module_size),
+                    fill=(r, g, b)
+                )


### PR DESCRIPTION
I have added `module_size` parameter into QRImage() constructor to change module size. The following code is an example of usage.
```py
image = QRImage(qr, module_size=8)
```