### PR TITLE
add `get_ndarray`

### DIFF
--- a/example.py
+++ b/example.py
@@ -5,6 +5,7 @@ from rmqrcode import FitStrategy
 
 import logging
 
+USE_NUMPY = True
 
 def main():
     data = "https://oudon.xyz"
@@ -25,6 +26,14 @@ def main():
     image = QRImage(qr, module_size=8)
     image.show()
     image.save("my_qr.png")
+
+    # Convert to numpy array
+    if USE_NUMPY:
+        import cv2
+        img = image.get_ndarray()
+        cv2.imshow("img", img)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
 
 
 def _init_logger():

--- a/src/rmqrcode/qr_image.py
+++ b/src/rmqrcode/qr_image.py
@@ -3,7 +3,6 @@ from .enums.color import Color
 from PIL import Image
 from PIL import ImageDraw
 
-
 class QRImage:
     def __init__(self, qr, module_size=10):
         self._module_size = module_size
@@ -14,11 +13,17 @@ class QRImage:
         )
         self._make_image(qr)
 
-
     def show(self):
         self._img.show()
         pass
 
+    def get_ndarray(self):
+        try:
+            import numpy as np
+        except ImportError:
+            raise ImportError("numpy is not installed")
+
+        return np.array(self._img)
 
     def save(self, name):
         self._img.save(name)


### PR DESCRIPTION
Thank you for the great repository. :smile: 

I propose a modification to convert to np.ndarray, as the process of creating the program required compositing with other images.

Use `get_ndarray()` to convert for OpenCV. 

```python
 ...
    image = QRImage(qr, module_size=8)

    if USE_NUMPY:
        import cv2
        img = image.get_ndarray()
        cv2.imshow("img", img)
        cv2.waitKey(0)
        cv2.destroyAllWindows()
```

As this is a very simple change, no changes are made to the Requirements.