### PR TITLE
BREAKING CHANGE: Add the option `with_quiet_zone`

### DIFF
--- a/src/rmqrcode/qr_image.py
+++ b/src/rmqrcode/qr_image.py
@@ -1,7 +1,5 @@
 from PIL import Image, ImageDraw
 
-from .enums.color import Color
-
 
 class QRImage:
     def __init__(self, qr, module_size=10):

--- a/src/rmqrcode/qr_image.py
+++ b/src/rmqrcode/qr_image.py
@@ -6,10 +6,11 @@ from .enums.color import Color
 class QRImage:
     def __init__(self, qr, module_size=10):
         self._module_size = module_size
+        qr_list = qr.to_list()
         self._img = Image.new(
-            "RGB", ((qr.width() + 4) * module_size, (qr.height() + 4) * module_size), (255, 255, 255)
+            "RGB", (len(qr_list[0]) * module_size, len(qr_list) * module_size), (255, 255, 255)
         )
-        self._make_image(qr)
+        self._make_image(qr_list)
 
     def show(self):
         self._img.show()
@@ -26,25 +27,17 @@ class QRImage:
     def save(self, name):
         self._img.save(name)
 
-    def _make_image(self, qr):
+    def _make_image(self, qr_list):
         draw = ImageDraw.Draw(self._img)
-        for y in range(qr.height()):
-            for x in range(qr.width()):
-                r, g, b = 125, 125, 125
-                if qr.value_at(x, y) == Color.BLACK:
-                    r, g, b = 0, 0, 0
-                elif qr.value_at(x, y) == Color.WHITE:
-                    r, g, b, = (
-                        255,
-                        255,
-                        255,
-                    )
+        for y in range(len(qr_list)):
+            for x in range(len(qr_list[0])):
+                r, g, b = (0, 0, 0) if qr_list[y][x] else (255, 255, 255)
                 draw.rectangle(
                     xy=(
-                        (x + 2) * self._module_size,
-                        (y + 2) * self._module_size,
-                        (x + 1 + 2) * self._module_size,
-                        (y + 1 + 2) * self._module_size,
+                        x * self._module_size,
+                        y * self._module_size,
+                        (x + 1) * self._module_size,
+                        (y + 1) * self._module_size,
                     ),
                     fill=(r, g, b),
                 )

--- a/src/rmqrcode/qr_image.py
+++ b/src/rmqrcode/qr_image.py
@@ -7,9 +7,7 @@ class QRImage:
     def __init__(self, qr, module_size=10):
         self._module_size = module_size
         qr_list = qr.to_list()
-        self._img = Image.new(
-            "RGB", (len(qr_list[0]) * module_size, len(qr_list) * module_size), (255, 255, 255)
-        )
+        self._img = Image.new("RGB", (len(qr_list[0]) * module_size, len(qr_list) * module_size), (255, 255, 255))
         self._make_image(qr_list)
 
     def show(self):

--- a/src/rmqrcode/rmqrcode.py
+++ b/src/rmqrcode/rmqrcode.py
@@ -125,7 +125,7 @@ class rMQR:
         return res
 
     def _to_binary_list(self):
-            return [list(map(lambda x: 1 if x == Color.BLACK else 0, column)) for column in self._qr]
+        return [list(map(lambda x: 1 if x == Color.BLACK else 0, column)) for column in self._qr]
 
     def __str__(self, with_quiet_zone=True):
         res = ""
@@ -139,7 +139,7 @@ class rMQR:
 
         res += f"rMQR Version R{self._height}x{self._width}:\n"
         if with_quiet_zone:
-            res += (show[False] * (self.width() + self.QUIET_ZONE_MODULES * 2) + '\n') * self.QUIET_ZONE_MODULES
+            res += (show[False] * (self.width() + self.QUIET_ZONE_MODULES * 2) + "\n") * self.QUIET_ZONE_MODULES
 
         for i in range(self.height()):
             if with_quiet_zone:
@@ -156,7 +156,7 @@ class rMQR:
             res += "\n"
 
         if with_quiet_zone:
-            res += (show[False] * (self.width() + self.QUIET_ZONE_MODULES * 2) + '\n') * self.QUIET_ZONE_MODULES
+            res += (show[False] * (self.width() + self.QUIET_ZONE_MODULES * 2) + "\n") * self.QUIET_ZONE_MODULES
         return res
 
     def _put_finder_pattern(self):

--- a/tests/rmqrcode_test.py
+++ b/tests/rmqrcode_test.py
@@ -14,6 +14,12 @@ class TestRMQR:
         qr = rMQR('R13x99', ErrorCorrectionLevel.M)
         qr.make("abc")
 
+        assert len(qr.to_list(with_quiet_zone=True)) is 17
+        assert len(qr.to_list(with_quiet_zone=True)[0]) is 103
+
+        assert len(qr.to_list(with_quiet_zone=False)) is 13
+        assert len(qr.to_list(with_quiet_zone=False)[0]) is 99
+
     def test_raise_too_long_error(self):
         with pytest.raises(DataTooLongError) as e:
             s = "a".ljust(200, "a")


### PR DESCRIPTION
This PR includes _**BREAKING CHANGE**_. 

## Issue Number
#15 

## Change
I have add the option `with_quiet_zone` into below methods.

- rMQR#to_list
- rMQR#__str__

`rMQR#to_lsit` returns a list with the quiet zone.  To return a list without the quiet zone, set False to the option `with_quiet_zone`.  Because the default value of the `with_quiet_zone` is True, this breaks current behavior.
