### PR TITLE
fix: block definitions of R13x27 and R17x43

### DIFF
--- a/src/rmqrcode/format/rmqr_versions.py
+++ b/src/rmqrcode/format/rmqr_versions.py
@@ -577,7 +577,7 @@ rMQRVersions = {
                 {
                     "num": 1,
                     "c": 21,
-                    "k": 14,
+                    "k": 12,
                 },
             ],
             ErrorCorrectionLevel.H: [
@@ -994,7 +994,7 @@ rMQRVersions = {
             ErrorCorrectionLevel.M: [
                 {
                     "num": 1,
-                    "c": 60,
+                    "c": 61,
                     "k": 39,
                 },
             ],


### PR DESCRIPTION
This fixes the below issues.

|Version|ErrorCorrectionLevel|Issue|
|:---:|:---:|:---|
|`R13x27`|`M`|fix #52|
|`R17x43`|`M`|fix #53|